### PR TITLE
Add handbook navigation elements to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,23 @@
 # Inquirer Data Engineering Team Handbook
 
-This Handbook is intended to provide all employees a guide to working on the Inquirer's Data Engineering (DE) team. It is a working, living document that will be updated over time as we grow and learn.
+This Handbook is intended to provide all employees a guide to working on the Inquirer's Data Engineering (DE) team, both for team members and our collaborators. It is a working, living document that will be updated over time as we grow and learn.
 
 You will find much of the content in this Handbook to be high-level, and subject to liberal interpretation and leeway. While this approach empowers our team members, it also means there is a **higher burden of responsibility**. We are trusting and expecting everyone to apply good judgement, and reach out for clarifications or guidance where things aren't clear or obvious. **This Handbook is meant to augment – not replace – good decision-making.**
+
+## Getting Started
+
+### For Everyone
+All new team members and collaborators should start by understanding our [Operating Principles](handbook/operating-principles.md). If you are looking to go deeper, begin by looking at [Our Values](handbook/values.md) and [how we communicate](handbook/communication.md).
+
+### For team members and frequent collaborators
+
+The Data Engineering team is responsible for The Inquirer Data Platform, which is made up of several distinct subcomponents and [technologies](handbook/technology). We make significant use of [dbt](handbook/technology/dbt.md) as a common tool.
+
+We track our work as [Objectives and Key Results](handbook/okrs/) both for the team and as individuals.
+
+We use a version of the Agile Project Management approach, colloquially referred to as our [Sprint Process](handbook/sprint-process.md)
+
+## About The Handbook
 
 We've borrowed heavily from [Hex](https://www.notion.so/Hex-Handbook-9fff0d42860e4f70815c599e0d1664d6) and [GitLab's](https://about.gitlab.com/handbook/business-technology/data-team/) handbooks in crafting our own. Both companies are exemplary in their efforts to promote impactful behaviors (and GitLab [welcomes](https://about.gitlab.com/handbook/values/#why-our-values-are-public) the copying and pasting of their [handbook contents](https://gitlab.com/gitlab-com/www-gitlab-com/-/blob/master/sites/handbook/source/handbook/handbook-usage/index.html.md#L298) under a [Creative Commons 4.0 International Attribution Share-Alike License](https://creativecommons.org/licenses/by-sa/4.0/)). We're grateful that they invested the time and effort to write their findings down. We will strive to do the same.
 

--- a/handbook/operating-principles.md
+++ b/handbook/operating-principles.md
@@ -4,7 +4,8 @@
 There are three **Data Engineering Team Operating Principles**: 
 
 ### 1. Build A Better Team
-- [CREDIT](handbook/values/#credit)
+
+- [CREDIT](values#credit)
 - We treat everyone with respect
 - We assume best intent towards the Inquirer's success
 - We are honest with ourselves and with each other
@@ -14,6 +15,7 @@ There are three **Data Engineering Team Operating Principles**:
 - We tackle mistakes as a team and seek to get better
 
 ### 2. Deliver Results That Matter
+
 - We operate with a [growth mindset](https://hbr.org/2016/01/what-having-a-growth-mindset-actually-means), continually raising the standard
 - We don’t confuse activity with progress
 - We know how our work aligns with strategic initiatives and how it will help our Business Partners deliver impactful results
@@ -21,6 +23,7 @@ There are three **Data Engineering Team Operating Principles**:
 - We proactively engage with our Business Partners to ensure regular progress for important initiatives
 
 ###  3. Create Trusted & Scalable Data Solutions
+
 - We all have a responsibility for Data Security and Data Quality
 - We lead with well-tested and accurate Data Solutions
 - We operate and maintain the production solutions we create
@@ -30,7 +33,8 @@ There are three **Data Engineering Team Operating Principles**:
 - Automated tests are the best tests and we implement tests at every step of the data delivery process
 
 
-### Additional beliefs held by the Data Engineering Team include:
+## Additional beliefs held by the Data Engineering Team include:
+
 * Everything can and should be defined in code and version controlled
 * Data implementations should integrate best practices from DevOps into their workflow
 * Partner with each Business function while having a high-quality, maintainable code base


### PR DESCRIPTION
Allows us to link / embed readme.md in other contexts (e.g. confluence).